### PR TITLE
Do not update ttl on reads for absolute expirations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - [#13](https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/pull/13) Bumping dependency to SDK 3.5.0 and adding Consistency readme
+- [#16](https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/pull/16) Do not update \_ts on reads for absolute expirations
 
 ## <a name="1.0.0"/> 1.0.0 - 2019-09-19
 

--- a/src/CosmosCache.cs
+++ b/src/CosmosCache.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.Extensions.Caching.Cosmos
 {
     using System;
-    using System.Collections.ObjectModel;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
@@ -99,6 +98,65 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 return null;
             }
 
+            // If using sliding expiration then replace item with itself in order to reset the ttl in Cosmos
+            if (cosmosCacheSessionResponse.Resource.IsSlidingExpiration.GetValueOrDefault())
+            {
+                try
+                {
+                    await this.cosmosContainer.ReplaceItemAsync(
+                            partitionKey: new PartitionKey(key),
+                            id: key,
+                            item: cosmosCacheSessionResponse.Resource,
+                            requestOptions: new ItemRequestOptions()
+                            {
+                                IfMatchEtag = cosmosCacheSessionResponse.ETag,
+                            },
+                            cancellationToken: token).ConfigureAwait(false);
+                }
+                catch (CosmosException cosmosException) when (cosmosException.StatusCode == HttpStatusCode.PreconditionFailed)
+                {
+                    // Race condition on replace, we need to get the latest version of the item
+                    return await this.GetAsync(key, token).ConfigureAwait(false);
+                }
+            }
+
+            return cosmosCacheSessionResponse.Resource.Content;
+        }
+
+        /// <inheritdoc/>
+        public void Refresh(string key)
+        {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+            this.RefreshAsync(key).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+        }
+
+        /// <inheritdoc/>
+        public async Task RefreshAsync(string key, CancellationToken token = default(CancellationToken))
+        {
+            token.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            await this.ConnectAsync();
+
+            ItemResponse<CosmosCacheSession> cosmosCacheSessionResponse;
+            try
+            {
+                cosmosCacheSessionResponse = await this.cosmosContainer.ReadItemAsync<CosmosCacheSession>(
+                    partitionKey: new PartitionKey(key),
+                    id: key,
+                    requestOptions: null,
+                    cancellationToken: token).ConfigureAwait(false);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                return;
+            }
+
             try
             {
                 await this.cosmosContainer.ReplaceItemAsync(
@@ -113,23 +171,8 @@ namespace Microsoft.Extensions.Caching.Cosmos
             }
             catch (CosmosException cosmosException) when (cosmosException.StatusCode == HttpStatusCode.PreconditionFailed)
             {
-                // Race condition on replace, we need to get the latest version of the item
-                return await this.GetAsync(key, token).ConfigureAwait(false);
+                // Race condition on replace, we do not need to refresh it
             }
-
-            return cosmosCacheSessionResponse.Resource.Content;
-        }
-
-        /// <inheritdoc/>
-        public void Refresh(string key)
-        {
-            this.Get(key);
-        }
-
-        /// <inheritdoc/>
-        public Task RefreshAsync(string key, CancellationToken token = default(CancellationToken))
-        {
-            return this.GetAsync(key, token);
         }
 
         /// <inheritdoc/>
@@ -215,6 +258,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 SessionKey = key,
                 Content = content,
                 TimeToLive = timeToLive,
+                IsSlidingExpiration = timeToLive.HasValue ? options.SlidingExpiration.HasValue : (bool?)null,
             };
         }
 

--- a/src/CosmosCache.cs
+++ b/src/CosmosCache.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 SessionKey = key,
                 Content = content,
                 TimeToLive = timeToLive,
-                IsSlidingExpiration = timeToLive.HasValue ? options.SlidingExpiration.HasValue : (bool?)null,
+                IsSlidingExpiration = timeToLive.HasValue && options.SlidingExpiration.HasValue,
             };
         }
 

--- a/src/CosmosCacheSession.cs
+++ b/src/CosmosCacheSession.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Extensions.Caching.Cosmos
 {
+    using Microsoft.Extensions.Caching.Distributed;
     using Newtonsoft.Json;
 
     internal class CosmosCacheSession
@@ -16,5 +17,14 @@ namespace Microsoft.Extensions.Caching.Cosmos
 
         [JsonProperty("ttl")]
         public long? TimeToLive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="TimeToLive"/> is sliding or absolute.<br/>
+        /// True if <see cref="DistributedCacheEntryOptions.SlidingExpiration"/> was set and used for the TTL,
+        /// false if <see cref="DistributedCacheEntryOptions.AbsoluteExpiration"/> or <see cref="DistributedCacheEntryOptions.AbsoluteExpirationRelativeToNow"/> was set and used for the TTL;
+        /// otherwise null.
+        /// </summary>
+        [JsonProperty("isSlidingExpiration")]
+        public bool? IsSlidingExpiration { get; set; }
     }
 }

--- a/tests/unit/CosmosCacheTests.cs
+++ b/tests/unit/CosmosCacheTests.cs
@@ -66,12 +66,13 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
         }
 
         [Fact]
-        public async Task GetObtainsSessionAndUpdatesCache()
+        public async Task GetObtainsSessionAndUpdatesCacheForSlidingExpiration()
         {
             string etag = "etag";
             CosmosCacheSession existingSession = new CosmosCacheSession();
             existingSession.SessionKey = "key";
             existingSession.Content = new byte[0];
+            existingSession.IsSlidingExpiration = true;
             Mock<ItemResponse<CosmosCacheSession>> mockedItemResponse = new Mock<ItemResponse<CosmosCacheSession>>();
             Mock<CosmosClient> mockedClient = new Mock<CosmosClient>();
             Mock<Container> mockedContainer = new Mock<Container>();
@@ -98,6 +99,43 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             mockedClient.Verify(c => c.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetObtainsSessionAndDoesNotUpdatesCacheForAbsoluteExpiration()
+        {
+            string etag = "etag";
+            CosmosCacheSession existingSession = new CosmosCacheSession();
+            existingSession.SessionKey = "key";
+            existingSession.Content = new byte[0];
+            existingSession.IsSlidingExpiration = false;
+            Mock<ItemResponse<CosmosCacheSession>> mockedItemResponse = new Mock<ItemResponse<CosmosCacheSession>>();
+            Mock<CosmosClient> mockedClient = new Mock<CosmosClient>();
+            Mock<Container> mockedContainer = new Mock<Container>();
+            Mock<Database> mockedDatabase = new Mock<Database>();
+            Mock<ContainerResponse> mockedResponse = new Mock<ContainerResponse>();
+            mockedItemResponse.Setup(c => c.Resource).Returns(existingSession);
+            mockedItemResponse.Setup(c => c.ETag).Returns(etag);
+            mockedResponse.Setup(c => c.StatusCode).Returns(HttpStatusCode.OK);
+            mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedResponse.Object);
+            mockedContainer.Setup(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
+            mockedContainer.Setup(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
+            mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object);
+            mockedClient.Setup(c => c.GetDatabase(It.IsAny<string>())).Returns(mockedDatabase.Object);
+            mockedClient.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
+            CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions()
+            {
+                DatabaseName = "something",
+                ContainerName = "something",
+                CreateIfNotExists = true,
+                CosmosClient = mockedClient.Object
+            }));
+
+            Assert.Same(existingSession.Content, await cache.GetAsync("key"));
+            // Checks for Db existence due to CreateIfNotExists
+            mockedClient.Verify(c => c.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockedContainer.Verify(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockedContainer.Verify(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact]


### PR DESCRIPTION
Only update cached item ttl on reads if sliding expiration was explicitly set in cache entry options.

Closes #15 