### PR TITLE
TTL: Fix null attribute value on no expiration

### DIFF
--- a/src/CosmosCacheSession.cs
+++ b/src/CosmosCacheSession.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
         [JsonProperty("content")]
         public byte[] Content { get; set; }
 
-        [JsonProperty("ttl")]
+        [JsonProperty("ttl", NullValueHandling = NullValueHandling.Ignore)]
         public long? TimeToLive { get; set; }
 
         /// <summary>

--- a/src/CosmosDistributedCache.csproj
+++ b/src/CosmosDistributedCache.csproj
@@ -7,7 +7,7 @@
     <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd))</CurrentDate>
     <NeutralLanguage>en-US</NeutralLanguage>
     <ClientVersion>1.0.0</ClientVersion>
-    <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview</VersionSuffix>
+    <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview2</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' == '' ">$(ClientVersion)</Version>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(ClientVersion)-$(VersionSuffix)</Version>
     <FileVersion>$(ClientVersion)</FileVersion>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.9.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.0" />
   </ItemGroup>


### PR DESCRIPTION
When the Distributed Cache configuration was set for no expiration, the `ttl` property was being set to `null` and the write operation failed.

Closes #22