### PR TITLE
Adding support for Gremlin accounts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- [#31](https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/pull/31) Added support for Gremlin accounts
+
 ## <a name="1.0.0-preview4"/> 1.0.0-preview4 - 2020-07-27
 
 ### Added

--- a/src/CosmosCache.cs
+++ b/src/CosmosCache.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
             {
                 try
                 {
+                    cosmosCacheSessionResponse.Resource.PartitionKeyAttribute = this.options.ContainerPartitionKeyAttribute;
                     await this.cosmosContainer.ReplaceItemAsync(
                             partitionKey: new PartitionKey(key),
                             id: key,
@@ -260,7 +261,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 Content = content,
                 TimeToLive = timeToLive,
                 IsSlidingExpiration = timeToLive.HasValue && options.SlidingExpiration.HasValue,
-                PartitionKeyDefinition = cosmosCacheOptions.ContainerPartitionKeyPath,
+                PartitionKeyAttribute = cosmosCacheOptions.ContainerPartitionKeyAttribute,
             };
         }
 
@@ -345,9 +346,9 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 {
                     // Container is optimized as Key-Value store excluding all properties
                     string partitionKeyDefinition = CosmosCache.ContainerPartitionKeyPath;
-                    if (!string.IsNullOrWhiteSpace(this.options.ContainerPartitionKeyPath))
+                    if (!string.IsNullOrWhiteSpace(this.options.ContainerPartitionKeyAttribute))
                     {
-                        partitionKeyDefinition = $"/{this.options.ContainerPartitionKeyPath}";
+                        partitionKeyDefinition = $"/{this.options.ContainerPartitionKeyAttribute}";
                     }
 
                     await this.cosmosClient.GetDatabase(this.options.DatabaseName).DefineContainer(this.options.ContainerName, partitionKeyDefinition)

--- a/src/CosmosCache.cs
+++ b/src/CosmosCache.cs
@@ -345,7 +345,13 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
                 {
                     // Container is optimized as Key-Value store excluding all properties
-                    await this.cosmosClient.GetDatabase(this.options.DatabaseName).DefineContainer(this.options.ContainerName, CosmosCache.ContainerPartitionKeyPath)
+                    string partitionKeyDefinition = CosmosCache.ContainerPartitionKeyPath;
+                    if (!string.IsNullOrWhiteSpace(this.options.ContainerPartitionKeyPath))
+                    {
+                        partitionKeyDefinition = $"/{this.options.ContainerPartitionKeyPath}";
+                    }
+
+                    await this.cosmosClient.GetDatabase(this.options.DatabaseName).DefineContainer(this.options.ContainerName, partitionKeyDefinition)
                         .WithDefaultTimeToLive(defaultTimeToLive)
                         .WithIndexingPolicy()
                             .WithIndexingMode(IndexingMode.Consistent)

--- a/src/CosmosCache.cs
+++ b/src/CosmosCache.cs
@@ -240,21 +240,19 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 item: CosmosCache.BuildCosmosCacheSession(
                     key,
                     value,
-                    options),
+                    options,
+                    this.options),
                 requestOptions: null,
                 cancellationToken: token).ConfigureAwait(false);
         }
 
-        private static CosmosCacheSession BuildCosmosCacheSession(string key, byte[] content, DistributedCacheEntryOptions options, DateTimeOffset? creationTime = null)
+        private static CosmosCacheSession BuildCosmosCacheSession(string key, byte[] content, DistributedCacheEntryOptions options, CosmosCacheOptions cosmosCacheOptions)
         {
-            if (!creationTime.HasValue)
-            {
-                creationTime = DateTimeOffset.UtcNow;
-            }
+            DateTimeOffset creationTime = DateTimeOffset.UtcNow;
 
-            DateTimeOffset? absoluteExpiration = CosmosCache.GetAbsoluteExpiration(creationTime.Value, options);
+            DateTimeOffset? absoluteExpiration = CosmosCache.GetAbsoluteExpiration(creationTime, options);
 
-            long? timeToLive = CosmosCache.GetExpirationInSeconds(creationTime.Value, absoluteExpiration, options);
+            long? timeToLive = CosmosCache.GetExpirationInSeconds(creationTime, absoluteExpiration, options);
 
             return new CosmosCacheSession()
             {
@@ -262,6 +260,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 Content = content,
                 TimeToLive = timeToLive,
                 IsSlidingExpiration = timeToLive.HasValue && options.SlidingExpiration.HasValue,
+                PartitionKeyDefinition = cosmosCacheOptions.ContainerPartitionKeyPath,
             };
         }
 

--- a/src/CosmosCacheOptions.cs
+++ b/src/CosmosCacheOptions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
         /// If <see cref="CreateIfNotExists"/> is true, it will be used to define the Partition Key of the created Container.
         /// </remarks>
         /// <value>Default value is "id".</value>
-        public string ContainerPartitionKeyPath { get; set; }
+        public string ContainerPartitionKeyAttribute { get; set; }
 
         /// <summary>
         /// Gets or sets the provisioned throughput for the Container in case <see cref="CreateIfNotExists"/> is true and the Container does not exist.

--- a/src/CosmosCacheOptions.cs
+++ b/src/CosmosCacheOptions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
         public bool CreateIfNotExists { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets a value indicating the name of the property used as Partition Key on the Container. 
+        /// Gets or sets a value indicating the name of the property used as Partition Key on the Container.
         /// </summary>
         /// <remarks>
         /// If <see cref="CreateIfNotExists"/> is true, it will be used to define the Partition Key of the created Container.

--- a/src/CosmosCacheOptions.cs
+++ b/src/CosmosCacheOptions.cs
@@ -36,7 +36,17 @@ namespace Microsoft.Extensions.Caching.Cosmos
         /// <summary>
         /// Gets or sets a value indicating whether initialization it will check for the Container existence and create it if it doesn't exist using <see cref="ContainerThroughput"/> as provisioned throughput and <see cref="DefaultTimeToLiveInMs"/>.
         /// </summary>
-        public bool CreateIfNotExists { get; set; }
+        /// <value>Default value is false.</value>
+        public bool CreateIfNotExists { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating the name of the property used as Partition Key on the Container. 
+        /// </summary>
+        /// <remarks>
+        /// If <see cref="CreateIfNotExists"/> is true, it will be used to define the Partition Key of the created Container.
+        /// </remarks>
+        /// <value>Default value is "id".</value>
+        public string ContainerPartitionKeyPath { get; set; }
 
         /// <summary>
         /// Gets or sets the provisioned throughput for the Container in case <see cref="CreateIfNotExists"/> is true and the Container does not exist.

--- a/src/CosmosCacheSession.cs
+++ b/src/CosmosCacheSession.cs
@@ -24,6 +24,6 @@ namespace Microsoft.Extensions.Caching.Cosmos
         /// </summary>
         public bool? IsSlidingExpiration { get; set; }
 
-        public string PartitionKeyDefinition { get; set; }
+        public string PartitionKeyAttribute { get; set; }
     }
 }

--- a/src/CosmosCacheSession.cs
+++ b/src/CosmosCacheSession.cs
@@ -23,5 +23,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
         /// otherwise null.
         /// </summary>
         public bool? IsSlidingExpiration { get; set; }
+
+        public string PartitionKeyDefinition { get; set; }
     }
 }

--- a/src/CosmosCacheSession.cs
+++ b/src/CosmosCacheSession.cs
@@ -7,15 +7,13 @@ namespace Microsoft.Extensions.Caching.Cosmos
     using Microsoft.Extensions.Caching.Distributed;
     using Newtonsoft.Json;
 
+    [JsonConverter(typeof(CosmosCacheSessionConverter))]
     internal class CosmosCacheSession
     {
-        [JsonProperty("id")]
         public string SessionKey { get; set; }
 
-        [JsonProperty("content")]
         public byte[] Content { get; set; }
 
-        [JsonProperty("ttl", NullValueHandling = NullValueHandling.Ignore)]
         public long? TimeToLive { get; set; }
 
         /// <summary>
@@ -24,7 +22,6 @@ namespace Microsoft.Extensions.Caching.Cosmos
         /// false if <see cref="DistributedCacheEntryOptions.AbsoluteExpiration"/> or <see cref="DistributedCacheEntryOptions.AbsoluteExpirationRelativeToNow"/> was set and used for the TTL;
         /// otherwise null.
         /// </summary>
-        [JsonProperty("isSlidingExpiration")]
         public bool? IsSlidingExpiration { get; set; }
     }
 }

--- a/src/CosmosCacheSessionConverter.cs
+++ b/src/CosmosCacheSessionConverter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
 
             if (jObject.TryGetValue(CosmosCacheSessionConverter.PkAttributeName, out JToken pkDefinitionJToken))
             {
-                cosmosCacheSession.PartitionKeyDefinition = pkDefinitionJToken.Value<string>();
+                cosmosCacheSession.PartitionKeyAttribute = pkDefinitionJToken.Value<string>();
             }
 
             return cosmosCacheSession;
@@ -89,10 +89,10 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 writer.WriteValue(cosmosCacheSession.IsSlidingExpiration.Value);
             }
 
-            if (!string.IsNullOrWhiteSpace(cosmosCacheSession.PartitionKeyDefinition)
-                && !CosmosCacheSessionConverter.IdAttributeName.Equals(cosmosCacheSession.PartitionKeyDefinition, StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(cosmosCacheSession.PartitionKeyAttribute)
+                && !CosmosCacheSessionConverter.IdAttributeName.Equals(cosmosCacheSession.PartitionKeyAttribute, StringComparison.OrdinalIgnoreCase))
             {
-                writer.WritePropertyName(cosmosCacheSession.PartitionKeyDefinition);
+                writer.WritePropertyName(cosmosCacheSession.PartitionKeyAttribute);
                 writer.WriteValue(cosmosCacheSession.SessionKey);
             }
 

--- a/src/CosmosCacheSessionConverter.cs
+++ b/src/CosmosCacheSessionConverter.cs
@@ -1,0 +1,79 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Extensions.Caching.Cosmos
+{
+    using System;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    internal class CosmosCacheSessionConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => objectType == typeof(CosmosCacheSession);
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType != JsonToken.StartObject)
+            {
+                throw new JsonReaderException();
+            }
+            
+            JObject jObject = JObject.Load(reader);
+            CosmosCacheSession cosmosCacheSession = new CosmosCacheSession();
+
+            if (!jObject.TryGetValue("id", out JToken idJToken))
+            {
+                throw new JsonReaderException("Missing id on Cosmos DB session item.");
+            }
+
+            cosmosCacheSession.SessionKey = idJToken.Value<string>();
+
+            if (!jObject.TryGetValue("content", out JToken contentJToken))
+            {
+                throw new JsonReaderException("Missing id on Cosmos DB session item.");
+            }
+
+            cosmosCacheSession.Content = contentJToken.Value<byte[]>();
+
+            if (jObject.TryGetValue("ttl", out JToken ttlJToken))
+            {
+                cosmosCacheSession.TimeToLive = ttlJToken.Value<long>();
+            }
+
+            if (jObject.TryGetValue("isSlidingExpiration", out JToken ttlSlidingExpiration))
+            {
+                cosmosCacheSession.IsSlidingExpiration = ttlSlidingExpiration.Value<bool>();
+            }
+
+            return cosmosCacheSession;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            CosmosCacheSession cosmosCacheSession = value as CosmosCacheSession;
+            writer.WritePropertyName("id");
+            writer.WriteValue(cosmosCacheSession.SessionKey);
+
+            writer.WritePropertyName("content");
+            writer.WriteValue(cosmosCacheSession.Content);
+
+            if (cosmosCacheSession.TimeToLive.HasValue)
+            {
+                writer.WritePropertyName("ttl");
+                writer.WriteValue(cosmosCacheSession.TimeToLive.Value);
+            }
+
+            if (cosmosCacheSession.IsSlidingExpiration.HasValue)
+            {
+                writer.WritePropertyName("isSlidingExpiration");
+                writer.WriteValue(cosmosCacheSession.IsSlidingExpiration.Value);
+            }
+        }
+    }
+}

--- a/tests/unit/CosmosCacheTests.cs
+++ b/tests/unit/CosmosCacheTests.cs
@@ -352,15 +352,5 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             await cache.SetAsync(existingSession.SessionKey, existingSession.Content, cacheOptions);
             mockedContainer.Verify(c => c.UpsertItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item.SessionKey == existingSession.SessionKey && item.TimeToLive == ttl), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
-
-        [Fact]
-        public void ValidatesNullTtlDoesNotSerializeProperty()
-        {
-            CosmosCacheSession existingSession = new CosmosCacheSession();
-            existingSession.SessionKey = "key";
-            existingSession.Content = new byte[0];
-            string serialized = JsonConvert.SerializeObject(existingSession);
-            Assert.False(serialized.Contains("\"ttl\""), "Session without expiration should not include ttl property.");
-        }
     }
 }

--- a/tests/unit/CosmosSessionSerializationTests.cs
+++ b/tests/unit/CosmosSessionSerializationTests.cs
@@ -1,0 +1,57 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Extensions.Caching.Cosmos.Tests
+{
+    using System;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.Fluent;
+    using Microsoft.Extensions.Caching.Cosmos;
+    using Microsoft.Extensions.Caching.Distributed;
+    using Microsoft.Extensions.Options;
+    using Moq;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public class CosmosSessionSerializationTests
+    {
+        [Fact]
+        public void ValidatesNullTtlDoesNotSerializeProperty()
+        {
+            CosmosCacheSession existingSession = new CosmosCacheSession();
+            existingSession.SessionKey = "key";
+            existingSession.Content = new byte[0];
+            string serialized = JsonConvert.SerializeObject(existingSession);
+            Assert.False(serialized.Contains("\"ttl\""), "Session without expiration should not include ttl property.");
+        }
+
+        [Fact]
+        public void ValidatesCustomPartitionKeyCreatesProperty()
+        {
+            const string pkProperty = "notTheId";
+            CosmosCacheSession existingSession = new CosmosCacheSession();
+            existingSession.SessionKey = "key";
+            existingSession.Content = new byte[0];
+            existingSession.PartitionKeyAttribute = pkProperty;
+            string serialized = JsonConvert.SerializeObject(existingSession);
+            Assert.True(serialized.Contains($"\"{pkProperty}\""), "Missing custom partition key.");
+        }
+
+        [Fact]
+        public void ValidatesContract()
+        {
+            const string expectedContract = "{\"id\":\"key\",\"content\":\"AQ==\",\"ttl\":5,\"isSlidingExpiration\":true}";
+            CosmosCacheSession existingSession = new CosmosCacheSession();
+            existingSession.SessionKey = "key";
+            existingSession.IsSlidingExpiration = true;
+            existingSession.TimeToLive = 5;
+            existingSession.Content = new byte[1] { 1 };
+            string serialized = JsonConvert.SerializeObject(existingSession);
+            Assert.Equal(expectedContract , serialized);
+        }
+    }
+}


### PR DESCRIPTION
Cosmos DB Gremlin accounts have a limitation regarding the partition key path that can be used in their containers (cannot use `/id`).

This PR adds a new `CosmosCacheOptions` property called `ContainerPartitionKeyAttribute` to be used like this:

```
services.AddCosmosCache((CosmosCacheOptions cacheOptions) =>
{
    cacheOptions.ContainerName = Configuration["CosmosCacheContainer"];
    cacheOptions.DatabaseName = Configuration["CosmosCacheDatabase"];
    cacheOptions.ClientBuilder = new CosmosClientBuilder(Configuration["CosmosConnectionString"]);
    cacheOptions.CreateIfNotExists = true;
    cacheOptions.ContainerPartitionKeyAttribute = "myDesiredName";
});
```

That will make the session items to contain a property called "myDesiredName" that will be used as Partition Key value. The value will be the same as the "id" property.

The PR also adds the required tests.

Closes #30