### PR TITLE
Fix remove not exist key got exception related to Resource Not Found

### DIFF
--- a/src/CosmosCache.cs
+++ b/src/CosmosCache.cs
@@ -220,12 +220,18 @@ namespace Microsoft.Extensions.Caching.Cosmos
             }
 
             await this.ConnectAsync().ConfigureAwait(false);
-
-            await this.cosmosContainer.DeleteItemAsync<CosmosCacheSession>(
-                partitionKey: new PartitionKey(key),
-                id: key,
-                requestOptions: null,
-                cancellationToken: token).ConfigureAwait(false);
+            try
+            {
+                await this.cosmosContainer.DeleteItemAsync<CosmosCacheSession>(
+                    partitionKey: new PartitionKey(key),
+                    id: key,
+                    requestOptions: null,
+                    cancellationToken: token).ConfigureAwait(false);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                return;
+            }
         }
 
         /// <inheritdoc/>

--- a/src/CosmosCache.cs
+++ b/src/CosmosCache.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
             }
             catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
             {
-                return;
+                // do nothing
             }
         }
 

--- a/tests/unit/CosmosCacheTests.cs
+++ b/tests/unit/CosmosCacheTests.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
         {
             var mockedClient = new Mock<CosmosClient>();
             var mockedContainer = new Mock<Container>();
-            mockedContainer.Setup(c => c.DeleteItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "not-exist-key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+            mockedContainer.Setup(c => c.DeleteItemAsync<CosmosCacheSession>("not-exist-key", It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new CosmosException("test remove not exist", HttpStatusCode.NotFound, 0, "", 0))
                 .Verifiable();
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object).Verifiable();
@@ -360,7 +360,7 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             }));
 
             await cache.RemoveAsync("not-exist-key");
-            mockedContainer.Verify(c => c.DeleteItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "not-exist-key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockedContainer.Verify(c => c.DeleteItemAsync<CosmosCacheSession>("not-exist-key", It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedClient.VerifyAll();
             mockedContainer.VerifyAll();
         }

--- a/tests/unit/CosmosCacheTests.cs
+++ b/tests/unit/CosmosCacheTests.cs
@@ -343,6 +343,27 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             await cache.RemoveAsync("key");
             mockedContainer.Verify(c => c.DeleteItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
+        
+        [Fact]
+        public async Task RemoveAsyncNotExistItem()
+        {
+            var mockedClient = new Mock<CosmosClient>();
+            var mockedContainer = new Mock<Container>();
+            mockedContainer.Setup(c => c.DeleteItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "not-exist-key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new CosmosException("test remove not exist", HttpStatusCode.NotFound, 0, "", 0))
+                .Verifiable();
+            mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object).Verifiable();
+            CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions(){
+                DatabaseName = "something",
+                ContainerName = "something",
+                CosmosClient = mockedClient.Object
+            }));
+
+            await cache.RemoveAsync("not-exist-key");
+            mockedContainer.Verify(c => c.DeleteItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "not-exist-key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockedClient.VerifyAll();
+            mockedContainer.VerifyAll();
+        }
 
         [Fact]
         public async Task SetAsyncCallsUpsert()


### PR DESCRIPTION
To fix this issue: #37 when remove a not exist cache entry

```
Microsoft.Azure.Cosmos.CosmosException : Response status code does not indicate success: NotFound (404); Substatus: 0; ActivityId: 970d262f-dfcf-4b01-8ec1-1a1f25ee18bb; Reason: ({
  "Errors": [
    "Resource Not Found. Learn more: https://aka.ms/cosmosdb-tsg-not-found"
  ]
});
   at Microsoft.Azure.Cosmos.ResponseMessage.EnsureSuccessStatusCode()
   at Microsoft.Azure.Cosmos.CosmosResponseFactoryCore.ProcessMessage[T](ResponseMessage responseMessage, Func`2 createResponse)
   at Microsoft.Azure.Cosmos.CosmosResponseFactoryCore.CreateItemResponse[T](ResponseMessage responseMessage)
   at Microsoft.Azure.Cosmos.ContainerCore.DeleteItemAsync[T](CosmosDiagnosticsContext diagnosticsContext, String id, PartitionKey partitionKey, ItemRequestOptions requestOptions, CancellationToken cancellationToken)
   at Microsoft.Azure.Cosmos.ClientContextCore.RunWithDiagnosticsHelperAsync[TResult](CosmosDiagnosticsContext diagnosticsContext, Func`2 task)
   at Microsoft.Extensions.Caching.Cosmos.CosmosCache.RemoveAsync(String key, CancellationToken token)
....
```