### PR TITLE
EnableContentResponseOnWrite to reduce network usage when not needed

### DIFF
--- a/src/CosmosCache.cs
+++ b/src/CosmosCache.cs
@@ -129,6 +129,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
                             requestOptions: new ItemRequestOptions()
                             {
                                 IfMatchEtag = cosmosCacheSessionResponse.ETag,
+                                EnableContentResponseOnWrite = false,
                             },
                             cancellationToken: token).ConfigureAwait(false);
                 }
@@ -191,6 +192,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
                             requestOptions: new ItemRequestOptions()
                             {
                                 IfMatchEtag = cosmosCacheSessionResponse.ETag,
+                                EnableContentResponseOnWrite = false,
                             },
                             cancellationToken: token).ConfigureAwait(false);
                 }
@@ -225,7 +227,10 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 await this.cosmosContainer.DeleteItemAsync<CosmosCacheSession>(
                     partitionKey: new PartitionKey(key),
                     id: key,
-                    requestOptions: null,
+                    requestOptions: new ItemRequestOptions()
+                    {
+                        EnableContentResponseOnWrite = false,
+                    },
                     cancellationToken: token).ConfigureAwait(false);
             }
             catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -271,7 +276,10 @@ namespace Microsoft.Extensions.Caching.Cosmos
                     value,
                     options,
                     this.options),
-                requestOptions: null,
+                requestOptions: new ItemRequestOptions()
+                {
+                    EnableContentResponseOnWrite = false,
+                },
                 cancellationToken: token).ConfigureAwait(false);
         }
 

--- a/src/CosmosDistributedCache.csproj
+++ b/src/CosmosDistributedCache.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.11.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.17.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.0" />
   </ItemGroup>


### PR DESCRIPTION
The SDK has `EnableContentResponseOnWrite` to avoid returning payload for write operations when it's not needed, this reduces network usage and potentially improves latency.