### PR TITLE
Adding Diagnostics capture APIs

### DIFF
--- a/src/CosmosCache.cs
+++ b/src/CosmosCache.cs
@@ -205,12 +205,12 @@ namespace Microsoft.Extensions.Caching.Cosmos
                             },
                             cancellationToken: token).ConfigureAwait(false);
 
-                    this.options.DiagnosticsHandler?.Invoke(replaceCacheSessionResponse.Diagnostics);    
+                    this.options.DiagnosticsHandler?.Invoke(replaceCacheSessionResponse.Diagnostics);
                 }
                 catch (CosmosException cosmosException) when (cosmosException.StatusCode == HttpStatusCode.PreconditionFailed)
                 {
-                    this.options.DiagnosticsHandler?.Invoke(cosmosException.Diagnostics);
                     // Race condition on replace, we need do not need to refresh it
+                    this.options.DiagnosticsHandler?.Invoke(cosmosException.Diagnostics);
                 }
             }
         }
@@ -249,8 +249,8 @@ namespace Microsoft.Extensions.Caching.Cosmos
             }
             catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
             {
-                this.options.DiagnosticsHandler?.Invoke(ex.Diagnostics);
                 // do nothing
+                this.options.DiagnosticsHandler?.Invoke(ex.Diagnostics);
             }
         }
 

--- a/src/CosmosCacheOptions.cs
+++ b/src/CosmosCacheOptions.cs
@@ -14,6 +14,30 @@ namespace Microsoft.Extensions.Caching.Cosmos
     public class CosmosCacheOptions : IOptions<CosmosCacheOptions>
     {
         /// <summary>
+        /// Delegate to receive Diagnostics from the internal Cosmos DB operations.
+        /// </summary>
+        /// <param name="diagnostics">An instance of <see cref="CosmosDiagnostics"/> result from a Cosmos DB service operation.</param>
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// void captureDiagnostics(CosmosDiagnostics diagnostics)
+        /// {
+        ///     if (diagnostics.GetClientElapsedTime() > SomePredefinedThresholdTime)
+        ///     {
+        ///         Console.WriteLine(diagnostics.ToString());
+        ///     }
+        /// }
+        ///
+        /// CosmosCacheOptions options = new CosmosCacheOptions(){
+        ///     /* Other options */,
+        ///     DiagnosticsHandler = captureDiagnostics
+        /// };
+        /// ]]>
+        /// </code>
+        /// </example>
+        public delegate void DiagnosticsDelegate(CosmosDiagnostics diagnostics);
+
+        /// <summary>
         /// Gets or sets an instance of <see cref="CosmosClientBuilder"/> to build a Cosmos Client with. Either use this or provide an existing <see cref="CosmosClient"/>.
         /// </summary>
         public CosmosClientBuilder ClientBuilder { get; set; }
@@ -76,20 +100,6 @@ namespace Microsoft.Extensions.Caching.Cosmos
         /// <para>Once set, it will be called for all executed operations and can be used for conditionally capturing diagnostics. </para>
         /// </remarks>
         public DiagnosticsDelegate DiagnosticsHandler { get; set; }
-
-
-        /// <summary>
-        /// Delegate to receive Diagnostics from the internal Cosmos DB operations.
-        /// </summary>
-        /// <example>
-        /// <code language="c#">
-        /// <![CDATA[
-        /// Container container = this.database.GetContainer("containerId");
-        /// ContainerProperties containerProperties = await container.ReadContainerAsync();
-        /// ]]>
-        /// </code>
-        /// </example>
-        public delegate void DiagnosticsDelegate (CosmosDiagnostics diagnostics);
 
         /// <summary>
         /// Gets the current options values.

--- a/src/CosmosCacheOptions.cs
+++ b/src/CosmosCacheOptions.cs
@@ -69,6 +69,29 @@ namespace Microsoft.Extensions.Caching.Cosmos
         public bool RetrySlidingExpirationUpdates { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a delegate to capture operation diagnostics.
+        /// </summary>
+        /// <remarks>
+        /// <para>This delegate captures the <see cref="CosmosDiagnostics"/> from the operations performed on the Cosmos DB service.</para>
+        /// <para>Once set, it will be called for all executed operations and can be used for conditionally capturing diagnostics. </para>
+        /// </remarks>
+        public DiagnosticsDelegate DiagnosticsHandler { get; set; }
+
+
+        /// <summary>
+        /// Delegate to receive Diagnostics from the internal Cosmos DB operations.
+        /// </summary>
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Container container = this.database.GetContainer("containerId");
+        /// ContainerProperties containerProperties = await container.ReadContainerAsync();
+        /// ]]>
+        /// </code>
+        /// </example>
+        public delegate void DiagnosticsDelegate (CosmosDiagnostics diagnostics);
+
+        /// <summary>
         /// Gets the current options values.
         /// </summary>
         CosmosCacheOptions IOptions<CosmosCacheOptions>.Value

--- a/tests/emulator/CosmosCacheEmulatorTests.cs
+++ b/tests/emulator/CosmosCacheEmulatorTests.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
@@ -34,6 +35,8 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
         [Fact]
         public async Task InitializeContainerIfNotExists()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             const string sessionId = "sessionId";
             const int ttl = 1400;
             const int throughput = 2000;
@@ -46,7 +49,8 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
                 ContainerThroughput = throughput,
                 CreateIfNotExists = true,
                 ClientBuilder = builder,
-                DefaultTimeToLiveInMs = ttl
+                DefaultTimeToLiveInMs = ttl,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             });
 
             CosmosCache cache = new CosmosCache(options);
@@ -64,6 +68,12 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             int? throughputContainer = await this.testClient.GetContainer(CosmosCacheEmulatorTests.databaseName, "session").ReadThroughputAsync();
 
             Assert.Equal(throughput, throughputContainer);
+
+            Assert.Equal(4, diagnosticsSink.CapturedDiagnostics.Count);
+            foreach (CosmosDiagnostics diagnostics in diagnosticsSink.CapturedDiagnostics)
+            {
+                Assert.NotNull(diagnostics?.ToString());
+            }
         }
 
         [Fact]
@@ -173,6 +183,8 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
         [Fact]
         public async Task GetSessionData()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             const string sessionId = "sessionId";
             const int ttl = 1400;
             const int throughput = 2000;
@@ -185,7 +197,8 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
                 DatabaseName = CosmosCacheEmulatorTests.databaseName,
                 ContainerThroughput = throughput,
                 CreateIfNotExists = true,
-                ClientBuilder = builder
+                ClientBuilder = builder,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             });
 
             CosmosCache cache = new CosmosCache(options);
@@ -194,11 +207,19 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             await cache.SetAsync(sessionId, data, cacheOptions);
 
             Assert.Equal(data, await cache.GetAsync(sessionId));
+
+            Assert.Equal(6, diagnosticsSink.CapturedDiagnostics.Count);
+            foreach (CosmosDiagnostics diagnostics in diagnosticsSink.CapturedDiagnostics)
+            {
+                Assert.NotNull(diagnostics?.ToString());
+            }
         }
 
         [Fact]
         public async Task RemoveSessionData()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             const string sessionId = "sessionId";
             const int ttl = 1400;
             const int throughput = 2000;
@@ -211,7 +232,8 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
                 DatabaseName = CosmosCacheEmulatorTests.databaseName,
                 ContainerThroughput = throughput,
                 CreateIfNotExists = true,
-                ClientBuilder = builder
+                ClientBuilder = builder,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             });
 
             CosmosCache cache = new CosmosCache(options);
@@ -223,6 +245,12 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
 
             CosmosException exception = await Assert.ThrowsAsync<CosmosException>(() => this.testClient.GetContainer(CosmosCacheEmulatorTests.databaseName, "session").ReadItemAsync<dynamic>(sessionId, new PartitionKey(sessionId)));
             Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
+
+            Assert.Equal(5, diagnosticsSink.CapturedDiagnostics.Count);
+            foreach (CosmosDiagnostics diagnostics in diagnosticsSink.CapturedDiagnostics)
+            {
+                Assert.NotNull(diagnostics?.ToString());
+            }
         }
 
         [Fact]
@@ -287,6 +315,8 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
         [Fact]
         public async Task RemoveSessionData_WhenNotExists()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             const string sessionId = "sessionId";
             const int ttl = 1400;
             const int throughput = 2000;
@@ -298,18 +328,27 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
                 DatabaseName = CosmosCacheEmulatorTests.databaseName,
                 ContainerThroughput = throughput,
                 CreateIfNotExists = true,
-                ClientBuilder = builder
+                ClientBuilder = builder,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             });
 
             CosmosCache cache = new CosmosCache(options);
             DistributedCacheEntryOptions cacheOptions = new DistributedCacheEntryOptions();
             cacheOptions.SlidingExpiration = TimeSpan.FromSeconds(ttl);
             await cache.RemoveAsync(sessionId);
+
+            Assert.Equal(4, diagnosticsSink.CapturedDiagnostics.Count);
+            foreach (CosmosDiagnostics diagnostics in diagnosticsSink.CapturedDiagnostics)
+            {
+                Assert.NotNull(diagnostics?.ToString());
+            }
         }
 
         [Fact]
         public async Task GetSessionData_WhenNotExists()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             const string sessionId = "sessionId";
             const int ttl = 1400;
             const int throughput = 2000;
@@ -321,13 +360,20 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
                 DatabaseName = CosmosCacheEmulatorTests.databaseName,
                 ContainerThroughput = throughput,
                 CreateIfNotExists = true,
-                ClientBuilder = builder
+                ClientBuilder = builder,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             });
 
             CosmosCache cache = new CosmosCache(options);
             DistributedCacheEntryOptions cacheOptions = new DistributedCacheEntryOptions();
             cacheOptions.SlidingExpiration = TimeSpan.FromSeconds(ttl);
             Assert.Null(await cache.GetAsync(sessionId));
+
+            Assert.Equal(4, diagnosticsSink.CapturedDiagnostics.Count);
+            foreach (CosmosDiagnostics diagnostics in diagnosticsSink.CapturedDiagnostics)
+            {
+                Assert.NotNull(diagnostics?.ToString());
+            }
         }
 
         [Fact]
@@ -430,6 +476,18 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
 
             [JsonProperty("ttl")]
             public long? TimeToLive { get; set; }
+        }
+
+        private class DiagnosticsSink 
+        {
+            private List<CosmosDiagnostics> capturedDiagnostics = new List<CosmosDiagnostics>();
+
+            public IReadOnlyList<CosmosDiagnostics> CapturedDiagnostics => this.capturedDiagnostics.AsReadOnly();
+
+            public void CaptureDiagnostics(CosmosDiagnostics diagnostics)
+            {
+                this.capturedDiagnostics.Add(diagnostics);
+            }
         }
     }
 }

--- a/tests/unit/CosmosCacheTests.cs
+++ b/tests/unit/CosmosCacheTests.cs
@@ -284,7 +284,8 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             mockedResponse.Setup(c => c.Diagnostics).Returns(mockedContainerDiagnostics.Object);
             mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedResponse.Object);
             mockedContainer.Setup(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
-            mockedContainer.Setup(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ThrowsAsync(new CosmosException("test", HttpStatusCode.PreconditionFailed, 0, "", 0));;
+            CosmosException preconditionFailedException = new CosmosException("test", HttpStatusCode.PreconditionFailed, 0, "", 0);
+            mockedContainer.Setup(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ThrowsAsync(preconditionFailedException);
             mockedDatabaseResponse.Setup(c => c.Diagnostics).Returns(mockedDatabaseDiagnostics.Object);
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object);
             mockedClient.Setup(c => c.GetDatabase(It.IsAny<string>())).Returns(mockedDatabase.Object);
@@ -309,7 +310,7 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             Assert.Same(mockedDatabaseDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[0]);
             Assert.Same(mockedContainerDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[1]);
             Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[2]);
-            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[3]);
+            Assert.Equal(preconditionFailedException.Diagnostics.ToString(), diagnosticsSink.CapturedDiagnostics[3].ToString());
         }
 
         [Fact]

--- a/tests/unit/CosmosCacheTests.cs
+++ b/tests/unit/CosmosCacheTests.cs
@@ -305,13 +305,11 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             mockedContainer.Verify(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
 
-            Assert.Equal(6, diagnosticsSink.CapturedDiagnostics.Count);
+            Assert.Equal(4, diagnosticsSink.CapturedDiagnostics.Count);
             Assert.Same(mockedDatabaseDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[0]);
             Assert.Same(mockedContainerDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[1]);
             Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[2]);
             Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[3]);
-            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[4]);
-            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[5]);
         }
 
         [Fact]

--- a/tests/unit/CosmosCacheTests.cs
+++ b/tests/unit/CosmosCacheTests.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Extensions.Caching.Cosmos.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
@@ -14,7 +15,6 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
     using Microsoft.Extensions.Caching.Distributed;
     using Microsoft.Extensions.Options;
     using Moq;
-    using Newtonsoft.Json;
     using Xunit;
 
     public class CosmosCacheTests
@@ -52,47 +52,64 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
         [Fact]
         public async Task ConnectAsyncThrowsIfContainerDoesNotExist()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             Mock<CosmosClient> mockedClient = new Mock<CosmosClient>();
             Mock<Container> mockedContainer = new Mock<Container>();
-            mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ThrowsAsync(new CosmosException("test", HttpStatusCode.NotFound, 0, "", 0));
+            CosmosException exception = new CosmosException("test", HttpStatusCode.NotFound, 0, "", 0);
+            mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ThrowsAsync(exception);
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object);
             mockedClient.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
             CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions(){
                 DatabaseName = "something",
                 ContainerName = "something",
-                CosmosClient = mockedClient.Object
+                CosmosClient = mockedClient.Object,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             }));
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => cache.GetAsync("key"));
+            Assert.Equal(1, diagnosticsSink.CapturedDiagnostics.Count);
+            Assert.Equal(exception.Diagnostics.ToString(), diagnosticsSink.CapturedDiagnostics[0].ToString());
         }
 
         [Fact]
         public async Task GetObtainsSessionAndUpdatesCacheForSlidingExpiration()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             string etag = "etag";
             CosmosCacheSession existingSession = new CosmosCacheSession();
             existingSession.SessionKey = "key";
             existingSession.Content = new byte[0];
             existingSession.IsSlidingExpiration = true;
             Mock<ItemResponse<CosmosCacheSession>> mockedItemResponse = new Mock<ItemResponse<CosmosCacheSession>>();
+            Mock<CosmosDiagnostics> mockedItemDiagnostics = new Mock<CosmosDiagnostics>();
             Mock<CosmosClient> mockedClient = new Mock<CosmosClient>();
             Mock<Container> mockedContainer = new Mock<Container>();
             Mock<Database> mockedDatabase = new Mock<Database>();
             Mock<ContainerResponse> mockedResponse = new Mock<ContainerResponse>();
+            Mock<CosmosDiagnostics> mockedContainerDiagnostics = new Mock<CosmosDiagnostics>();
+            Mock<DatabaseResponse> mockedDatabaseResponse = new Mock<DatabaseResponse>();
+            Mock<CosmosDiagnostics> mockedDatabaseDiagnostics = new Mock<CosmosDiagnostics>();
             mockedItemResponse.Setup(c => c.Resource).Returns(existingSession);
-            mockedItemResponse.Setup(c => c.ETag).Returns(etag);
+            mockedItemResponse.Setup(c => c.ETag).Returns(etag);            
+            mockedItemResponse.Setup(c => c.Diagnostics).Returns(mockedItemDiagnostics.Object);
             mockedResponse.Setup(c => c.StatusCode).Returns(HttpStatusCode.OK);
+            mockedResponse.Setup(c => c.Diagnostics).Returns(mockedContainerDiagnostics.Object);
             mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedResponse.Object);
             mockedContainer.Setup(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
             mockedContainer.Setup(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
+            mockedDatabaseResponse.Setup(c => c.Diagnostics).Returns(mockedDatabaseDiagnostics.Object);
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object);
             mockedClient.Setup(c => c.GetDatabase(It.IsAny<string>())).Returns(mockedDatabase.Object);
             mockedClient.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
+            mockedClient.Setup(x => x.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedDatabaseResponse.Object);
             CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions(){
                 DatabaseName = "something",
                 ContainerName = "something",
                 CreateIfNotExists = true,
-                CosmosClient = mockedClient.Object
+                CosmosClient = mockedClient.Object,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             }));
 
             Assert.Same(existingSession.Content, await cache.GetAsync("key"));
@@ -100,6 +117,12 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             mockedClient.Verify(c => c.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+
+            Assert.Equal(4, diagnosticsSink.CapturedDiagnostics.Count);
+            Assert.Same(mockedDatabaseDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[0]);
+            Assert.Same(mockedContainerDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[1]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[2]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[3]);
         }
 
         [Fact]
@@ -185,31 +208,42 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
         [Fact]
         public async Task GetObtainsSessionAndDoesNotUpdatesCacheForAbsoluteExpiration()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             string etag = "etag";
             CosmosCacheSession existingSession = new CosmosCacheSession();
             existingSession.SessionKey = "key";
             existingSession.Content = new byte[0];
             existingSession.IsSlidingExpiration = false;
             Mock<ItemResponse<CosmosCacheSession>> mockedItemResponse = new Mock<ItemResponse<CosmosCacheSession>>();
+            Mock<CosmosDiagnostics> mockedItemDiagnostics = new Mock<CosmosDiagnostics>();
             Mock<CosmosClient> mockedClient = new Mock<CosmosClient>();
             Mock<Container> mockedContainer = new Mock<Container>();
             Mock<Database> mockedDatabase = new Mock<Database>();
             Mock<ContainerResponse> mockedResponse = new Mock<ContainerResponse>();
+            Mock<CosmosDiagnostics> mockedContainerDiagnostics = new Mock<CosmosDiagnostics>();
+            Mock<DatabaseResponse> mockedDatabaseResponse = new Mock<DatabaseResponse>();
+            Mock<CosmosDiagnostics> mockedDatabaseDiagnostics = new Mock<CosmosDiagnostics>();
             mockedItemResponse.Setup(c => c.Resource).Returns(existingSession);
             mockedItemResponse.Setup(c => c.ETag).Returns(etag);
+            mockedItemResponse.Setup(c => c.Diagnostics).Returns(mockedItemDiagnostics.Object);
             mockedResponse.Setup(c => c.StatusCode).Returns(HttpStatusCode.OK);
+            mockedResponse.Setup(c => c.Diagnostics).Returns(mockedContainerDiagnostics.Object);
             mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedResponse.Object);
             mockedContainer.Setup(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
             mockedContainer.Setup(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
+            mockedDatabaseResponse.Setup(c => c.Diagnostics).Returns(mockedDatabaseDiagnostics.Object);
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object);
             mockedClient.Setup(c => c.GetDatabase(It.IsAny<string>())).Returns(mockedDatabase.Object);
             mockedClient.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
+            mockedClient.Setup(x => x.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedDatabaseResponse.Object);
             CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions()
             {
                 DatabaseName = "something",
                 ContainerName = "something",
                 CreateIfNotExists = true,
-                CosmosClient = mockedClient.Object
+                CosmosClient = mockedClient.Object,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             }));
 
             Assert.Same(existingSession.Content, await cache.GetAsync("key"));
@@ -217,36 +251,52 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             mockedClient.Verify(c => c.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+
+            Assert.Equal(3, diagnosticsSink.CapturedDiagnostics.Count);
+            Assert.Same(mockedDatabaseDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[0]);
+            Assert.Same(mockedContainerDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[1]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[2]);
         }
 
         [Fact]
         public async Task GetDoesNotRetryUpdateIfRetrySlidingExpirationUpdatesIsFalse()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             string etag = "etag";
             CosmosCacheSession existingSession = new CosmosCacheSession();
             existingSession.SessionKey = "key";
             existingSession.Content = new byte[0];
             existingSession.IsSlidingExpiration = true;
             Mock<ItemResponse<CosmosCacheSession>> mockedItemResponse = new Mock<ItemResponse<CosmosCacheSession>>();
+            Mock<CosmosDiagnostics> mockedItemDiagnostics = new Mock<CosmosDiagnostics>();
             Mock<CosmosClient> mockedClient = new Mock<CosmosClient>();
             Mock<Container> mockedContainer = new Mock<Container>();
             Mock<Database> mockedDatabase = new Mock<Database>();
             Mock<ContainerResponse> mockedResponse = new Mock<ContainerResponse>();
+            Mock<CosmosDiagnostics> mockedContainerDiagnostics = new Mock<CosmosDiagnostics>();
+            Mock<DatabaseResponse> mockedDatabaseResponse = new Mock<DatabaseResponse>();
+            Mock<CosmosDiagnostics> mockedDatabaseDiagnostics = new Mock<CosmosDiagnostics>();
             mockedItemResponse.Setup(c => c.Resource).Returns(existingSession);
             mockedItemResponse.Setup(c => c.ETag).Returns(etag);
+            mockedItemResponse.Setup(c => c.Diagnostics).Returns(mockedItemDiagnostics.Object);
             mockedResponse.Setup(c => c.StatusCode).Returns(HttpStatusCode.OK);
+            mockedResponse.Setup(c => c.Diagnostics).Returns(mockedContainerDiagnostics.Object);
             mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedResponse.Object);
             mockedContainer.Setup(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
             mockedContainer.Setup(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ThrowsAsync(new CosmosException("test", HttpStatusCode.PreconditionFailed, 0, "", 0));;
+            mockedDatabaseResponse.Setup(c => c.Diagnostics).Returns(mockedDatabaseDiagnostics.Object);
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object);
             mockedClient.Setup(c => c.GetDatabase(It.IsAny<string>())).Returns(mockedDatabase.Object);
             mockedClient.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
+            mockedClient.Setup(x => x.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedDatabaseResponse.Object);
             CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions(){
                 DatabaseName = "something",
                 ContainerName = "something",
                 CreateIfNotExists = true,
                 CosmosClient = mockedClient.Object,
-                RetrySlidingExpirationUpdates = false
+                RetrySlidingExpirationUpdates = false,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             }));
 
             Assert.Same(existingSession.Content, await cache.GetAsync("key"));
@@ -254,38 +304,58 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             mockedClient.Verify(c => c.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+
+            Assert.Equal(6, diagnosticsSink.CapturedDiagnostics.Count);
+            Assert.Same(mockedDatabaseDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[0]);
+            Assert.Same(mockedContainerDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[1]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[2]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[3]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[4]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[5]);
         }
 
         [Fact]
         public async Task GetDoesRetryUpdateIfRetrySlidingExpirationUpdatesIsTrue()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             string etag = "etag";
             CosmosCacheSession existingSession = new CosmosCacheSession();
             existingSession.SessionKey = "key";
             existingSession.Content = new byte[0];
             existingSession.IsSlidingExpiration = true;
             Mock<ItemResponse<CosmosCacheSession>> mockedItemResponse = new Mock<ItemResponse<CosmosCacheSession>>();
+            Mock<CosmosDiagnostics> mockedItemDiagnostics = new Mock<CosmosDiagnostics>();
             Mock<CosmosClient> mockedClient = new Mock<CosmosClient>();
             Mock<Container> mockedContainer = new Mock<Container>();
             Mock<Database> mockedDatabase = new Mock<Database>();
             Mock<ContainerResponse> mockedResponse = new Mock<ContainerResponse>();
+            Mock<CosmosDiagnostics> mockedContainerDiagnostics = new Mock<CosmosDiagnostics>();
+            Mock<DatabaseResponse> mockedDatabaseResponse = new Mock<DatabaseResponse>();
+            Mock<CosmosDiagnostics> mockedDatabaseDiagnostics = new Mock<CosmosDiagnostics>();
             mockedItemResponse.Setup(c => c.Resource).Returns(existingSession);
             mockedItemResponse.Setup(c => c.ETag).Returns(etag);
+            mockedItemResponse.Setup(c => c.Diagnostics).Returns(mockedItemDiagnostics.Object);
             mockedResponse.Setup(c => c.StatusCode).Returns(HttpStatusCode.OK);
+            mockedResponse.Setup(c => c.Diagnostics).Returns(mockedContainerDiagnostics.Object);
             mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedResponse.Object);
             mockedContainer.Setup(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
+            CosmosException preconditionException = new CosmosException("test", HttpStatusCode.PreconditionFailed, 0, "", 0);
             mockedContainer.SetupSequence(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new CosmosException("test", HttpStatusCode.PreconditionFailed, 0, "", 0))
+                .ThrowsAsync(preconditionException)
                 .ReturnsAsync(mockedItemResponse.Object);
+            mockedDatabaseResponse.Setup(c => c.Diagnostics).Returns(mockedDatabaseDiagnostics.Object);    
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object);
             mockedClient.Setup(c => c.GetDatabase(It.IsAny<string>())).Returns(mockedDatabase.Object);
             mockedClient.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
+            mockedClient.Setup(x => x.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedDatabaseResponse.Object);
             CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions(){
                 DatabaseName = "something",
                 ContainerName = "something",
                 CreateIfNotExists = true,
                 CosmosClient = mockedClient.Object,
-                RetrySlidingExpirationUpdates = true
+                RetrySlidingExpirationUpdates = true,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             }));
 
             Assert.Same(existingSession.Content, await cache.GetAsync("key"));
@@ -293,18 +363,31 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             mockedClient.Verify(c => c.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
             mockedContainer.Verify(c => c.ReplaceItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item == existingSession), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+
+            Assert.Equal(6, diagnosticsSink.CapturedDiagnostics.Count);
+            Assert.Same(mockedDatabaseDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[0]);
+            Assert.Same(mockedContainerDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[1]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[2]);
+            Assert.Equal(preconditionException.Diagnostics.ToString(), diagnosticsSink.CapturedDiagnostics[3].ToString());
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[4]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[5]);
         }
 
         [Fact]
         public async Task GetReturnsNullIfKeyDoesNotExist()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             Mock<CosmosClient> mockedClient = new Mock<CosmosClient>();
             Mock<Container> mockedContainer = new Mock<Container>();
             Mock<Database> mockedDatabase = new Mock<Database>();
             Mock<ContainerResponse> mockedResponse = new Mock<ContainerResponse>();
+            Mock<CosmosDiagnostics> mockedContainerDiagnostics = new Mock<CosmosDiagnostics>();
             mockedResponse.Setup(c => c.StatusCode).Returns(HttpStatusCode.OK);
+            mockedResponse.Setup(c => c.Diagnostics).Returns(mockedContainerDiagnostics.Object);
             mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedResponse.Object);
-            mockedContainer.Setup(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ThrowsAsync(new CosmosException("test", HttpStatusCode.NotFound, 0, "", 0));
+            CosmosException notFoundException = new CosmosException("test", HttpStatusCode.NotFound, 0, "", 0);
+            mockedContainer.Setup(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ThrowsAsync(notFoundException);
             mockedContainer.Setup(c => c.ReplaceItemAsync<CosmosCacheSession>(It.IsAny<CosmosCacheSession>(), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ThrowsAsync(new CosmosException("test", HttpStatusCode.NotFound, 0, "", 0));
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object);
             mockedClient.Setup(c => c.GetDatabase(It.IsAny<string>())).Returns(mockedDatabase.Object);
@@ -312,23 +395,34 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions(){
                 DatabaseName = "something",
                 ContainerName = "something",
-                CosmosClient = mockedClient.Object
+                CosmosClient = mockedClient.Object,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             }));
 
             Assert.Null(await cache.GetAsync("key"));
             mockedContainer.Verify(c => c.ReadItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedContainer.Verify(c => c.ReplaceItemAsync<CosmosCacheSession>(It.IsAny<CosmosCacheSession>(), It.Is<string>(id => id == "key"), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+
+            Assert.Equal(2, diagnosticsSink.CapturedDiagnostics.Count);
+            Assert.Same(mockedContainerDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[0]);
+            Assert.Equal(notFoundException.Diagnostics.ToString(), diagnosticsSink.CapturedDiagnostics[1].ToString());
         }
 
         [Fact]
         public async Task RemoveAsyncDeletesItem()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             Mock<ItemResponse<CosmosCacheSession>> mockedItemResponse = new Mock<ItemResponse<CosmosCacheSession>>();
+            Mock<CosmosDiagnostics> mockedItemDiagnostics = new Mock<CosmosDiagnostics>();
             Mock<CosmosClient> mockedClient = new Mock<CosmosClient>();
             Mock<Container> mockedContainer = new Mock<Container>();
             Mock<Database> mockedDatabase = new Mock<Database>();
             Mock<ContainerResponse> mockedResponse = new Mock<ContainerResponse>();
+            Mock<CosmosDiagnostics> mockedContainerDiagnostics = new Mock<CosmosDiagnostics>();
+            mockedItemResponse.Setup(c => c.Diagnostics).Returns(mockedItemDiagnostics.Object);
             mockedResponse.Setup(c => c.StatusCode).Returns(HttpStatusCode.OK);
+            mockedResponse.Setup(c => c.Diagnostics).Returns(mockedContainerDiagnostics.Object);
             mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedResponse.Object);
             mockedContainer.Setup(c => c.DeleteItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object);
@@ -337,37 +431,57 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions(){
                 DatabaseName = "something",
                 ContainerName = "something",
-                CosmosClient = mockedClient.Object
+                CosmosClient = mockedClient.Object,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             }));
 
             await cache.RemoveAsync("key");
             mockedContainer.Verify(c => c.DeleteItemAsync<CosmosCacheSession>(It.Is<string>(id => id == "key"), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+
+            Assert.Equal(2, diagnosticsSink.CapturedDiagnostics.Count);
+            Assert.Same(mockedContainerDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[0]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[1]);
         }
         
         [Fact]
         public async Task RemoveAsyncNotExistItem()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             var mockedClient = new Mock<CosmosClient>();
             var mockedContainer = new Mock<Container>();
+            Mock<ContainerResponse> mockedResponse = new Mock<ContainerResponse>();
+            Mock<CosmosDiagnostics> mockedContainerDiagnostics = new Mock<CosmosDiagnostics>();
+            mockedResponse.Setup(c => c.StatusCode).Returns(HttpStatusCode.OK);
+            mockedResponse.Setup(c => c.Diagnostics).Returns(mockedContainerDiagnostics.Object);
+            mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedResponse.Object);
+            CosmosException notExistException = new CosmosException("test remove not exist", HttpStatusCode.NotFound, 0, "", 0);
             mockedContainer.Setup(c => c.DeleteItemAsync<CosmosCacheSession>("not-exist-key", It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new CosmosException("test remove not exist", HttpStatusCode.NotFound, 0, "", 0))
+                .ThrowsAsync(notExistException)
                 .Verifiable();
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object).Verifiable();
             CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions(){
                 DatabaseName = "something",
                 ContainerName = "something",
-                CosmosClient = mockedClient.Object
+                CosmosClient = mockedClient.Object,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             }));
 
             await cache.RemoveAsync("not-exist-key");
             mockedContainer.Verify(c => c.DeleteItemAsync<CosmosCacheSession>("not-exist-key", It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             mockedClient.VerifyAll();
             mockedContainer.VerifyAll();
+
+            Assert.Equal(2, diagnosticsSink.CapturedDiagnostics.Count);
+            Assert.Same(mockedContainerDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[0]);
+            Assert.Equal(notExistException.Diagnostics.ToString(), diagnosticsSink.CapturedDiagnostics[1].ToString());
         }
 
         [Fact]
         public async Task SetAsyncCallsUpsert()
         {
+            DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
+
             int ttl = 10;
             DistributedCacheEntryOptions cacheOptions = new DistributedCacheEntryOptions();
             cacheOptions.SlidingExpiration = TimeSpan.FromSeconds(ttl);
@@ -376,11 +490,15 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             existingSession.SessionKey = "key";
             existingSession.Content = new byte[0];
             Mock<ItemResponse<CosmosCacheSession>> mockedItemResponse = new Mock<ItemResponse<CosmosCacheSession>>();
+            Mock<CosmosDiagnostics> mockedItemDiagnostics = new Mock<CosmosDiagnostics>();
             Mock<CosmosClient> mockedClient = new Mock<CosmosClient>();
             Mock<Container> mockedContainer = new Mock<Container>();
+            Mock<CosmosDiagnostics> mockedContainerDiagnostics = new Mock<CosmosDiagnostics>();
             Mock<Database> mockedDatabase = new Mock<Database>();
             Mock<ContainerResponse> mockedResponse = new Mock<ContainerResponse>();
             mockedResponse.Setup(c => c.StatusCode).Returns(HttpStatusCode.OK);
+            mockedResponse.Setup(c => c.Diagnostics).Returns(mockedContainerDiagnostics.Object);
+            mockedItemResponse.Setup(c => c.Diagnostics).Returns(mockedItemDiagnostics.Object);
             mockedContainer.Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedResponse.Object);
             mockedContainer.Setup(c => c.UpsertItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item.SessionKey == existingSession.SessionKey && item.TimeToLive == ttl), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedItemResponse.Object);
             mockedClient.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>())).Returns(mockedContainer.Object);
@@ -389,11 +507,16 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             CosmosCache cache = new CosmosCache(Options.Create(new CosmosCacheOptions(){
                 DatabaseName = "something",
                 ContainerName = "something",
-                CosmosClient = mockedClient.Object
+                CosmosClient = mockedClient.Object,
+                DiagnosticsHandler = diagnosticsSink.CaptureDiagnostics
             }));
 
             await cache.SetAsync(existingSession.SessionKey, existingSession.Content, cacheOptions);
             mockedContainer.Verify(c => c.UpsertItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item.SessionKey == existingSession.SessionKey && item.TimeToLive == ttl), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+
+            Assert.Equal(2, diagnosticsSink.CapturedDiagnostics.Count);
+            Assert.Same(mockedContainerDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[0]);
+            Assert.Same(mockedItemDiagnostics.Object, diagnosticsSink.CapturedDiagnostics[1]);
         }
 
         [Fact]
@@ -452,6 +575,18 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
 
             await cache.SetAsync(existingSession.SessionKey, existingSession.Content, cacheOptions);
             mockedContainer.Verify(c => c.UpsertItemAsync<CosmosCacheSession>(It.Is<CosmosCacheSession>(item => item.SessionKey == existingSession.SessionKey && item.TimeToLive == ttl), It.IsAny<PartitionKey?>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private class DiagnosticsSink 
+        {
+            private List<CosmosDiagnostics> capturedDiagnostics = new List<CosmosDiagnostics>();
+
+            public IReadOnlyList<CosmosDiagnostics> CapturedDiagnostics => this.capturedDiagnostics.AsReadOnly();
+
+            public void CaptureDiagnostics(CosmosDiagnostics diagnostics)
+            {
+                this.capturedDiagnostics.Add(diagnostics);
+            }
         }
     }
 }


### PR DESCRIPTION
## Scenario

When troubleshooting Cosmos DB interactions, obtaining the Diagnostics is key to understand what could be the reason for, for example, high latency operations.

## Solution

Since the `IDistributedCache` interface does not leave much room to extract any sort of diagnostics, this PR adds a callback delegate that can be used to track all Cosmos DB interactions that are happening on the back in cases where troubleshooting needs to be done.

```
void captureDiagnostics(CosmosDiagnostics diagnostics)
{
    if (diagnostics.GetClientElapsedTime() > SomePredefinedThresholdTime)
    {
        Console.WriteLine(diagnostics.ToString());
    }
}

CosmosCacheOptions options = new CosmosCacheOptions(){
    /* Other options */,
    DiagnosticsHandler = captureDiagnostics
};
```

The diagnostics can be conditionally captured based on latency or some other environment configuration.

They include all interactions (initialization, container operations, and item operations).