### PR TITLE
Fix DefaultTimeToLiveInMs handling when creating container

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- [#52](https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/pull/52) Fixed DefaultTimeToLiveInMs handling when creating container
+
 ## <a name="1.0.0"/> 1.0.0 - 2021-07-14
 
 ### Added

--- a/src/CosmosCache.cs
+++ b/src/CosmosCache.cs
@@ -400,7 +400,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
                 this.options.DiagnosticsHandler?.Invoke(databaseResponse.Diagnostics);
 
                 int defaultTimeToLive = this.options.DefaultTimeToLiveInMs.HasValue
-                    && this.options.DefaultTimeToLiveInMs.Value > 0 ? this.options.DefaultTimeToLiveInMs.Value : CosmosCache.DefaultTimeToLive;
+                    && this.options.DefaultTimeToLiveInMs.Value > 0 ? (int)TimeSpan.FromMilliseconds(this.options.DefaultTimeToLiveInMs.Value).TotalSeconds : CosmosCache.DefaultTimeToLive;
 
                 try
                 {

--- a/tests/emulator/CosmosCacheEmulatorTests.cs
+++ b/tests/emulator/CosmosCacheEmulatorTests.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
 
             const string sessionId = "sessionId";
-            const int ttl = 1400;
+            const int ttl = 2000;
+            const int ttlInSeconds = ttl / 1000;
             const int throughput = 2000;
 
             CosmosClientBuilder builder = new CosmosClientBuilder(ConfigurationManager.AppSettings["Endpoint"], ConfigurationManager.AppSettings["MasterKey"]);
@@ -55,14 +56,14 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
 
             CosmosCache cache = new CosmosCache(options);
             DistributedCacheEntryOptions cacheOptions = new DistributedCacheEntryOptions();
-            cacheOptions.SlidingExpiration = TimeSpan.FromSeconds(ttl);
+            cacheOptions.SlidingExpiration = TimeSpan.FromSeconds(ttlInSeconds);
             await cache.SetAsync(sessionId, new byte[0], cacheOptions);
 
             // Verify that container has been created
 
             ContainerResponse response = await this.testClient.GetContainer(CosmosCacheEmulatorTests.databaseName, "session").ReadContainerAsync();
             Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
-            Assert.Equal(ttl, response.Resource.DefaultTimeToLive);
+            Assert.Equal(ttlInSeconds, response.Resource.DefaultTimeToLive);
             Assert.True(response.Resource.IndexingPolicy.ExcludedPaths.Any(e => e.Path.Equals("/*")));
 
             int? throughputContainer = await this.testClient.GetContainer(CosmosCacheEmulatorTests.databaseName, "session").ReadThroughputAsync();
@@ -80,7 +81,8 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
         public async Task InitializeContainerIfNotExists_CustomPartitionKey()
         {
             const string sessionId = "sessionId";
-            const int ttl = 1400;
+            const int ttl = 2000;
+            const int ttlInSeconds = ttl / 1000;
             const int throughput = 2000;
             const string partitionKeyAttribute = "notTheId";
 
@@ -98,14 +100,14 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
 
             CosmosCache cache = new CosmosCache(options);
             DistributedCacheEntryOptions cacheOptions = new DistributedCacheEntryOptions();
-            cacheOptions.SlidingExpiration = TimeSpan.FromSeconds(ttl);
+            cacheOptions.SlidingExpiration = TimeSpan.FromSeconds(ttlInSeconds);
             await cache.SetAsync(sessionId, new byte[0], cacheOptions);
 
             // Verify that container has been created
 
             ContainerResponse response = await this.testClient.GetContainer(CosmosCacheEmulatorTests.databaseName, "session").ReadContainerAsync();
             Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
-            Assert.Equal(ttl, response.Resource.DefaultTimeToLive);
+            Assert.Equal(ttlInSeconds, response.Resource.DefaultTimeToLive);
             Assert.True(response.Resource.IndexingPolicy.ExcludedPaths.Any(e => e.Path.Equals("/*")));
             Assert.Equal($"/{partitionKeyAttribute}", response.Resource.PartitionKeyPath);
 


### PR DESCRIPTION
DefaultTimeToLiveInMs was not correctly handled and used to pass the configuration directly, when it should have been converted to seconds due to the property's name.

Closes #51