### PR TITLE
Errors: Fixes error text to point to correct missing property when deserializing session object

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- [#62](https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/pull/62) Fixed error text to point to correct missing property when deserializing session object
+
 ## <a name="1.2.0"/> 1.2.0 - 2022-02-23
 
 ### Added

--- a/src/CosmosCacheSessionConverter.cs
+++ b/src/CosmosCacheSessionConverter.cs
@@ -36,14 +36,14 @@ namespace Microsoft.Extensions.Caching.Cosmos
 
             if (!jObject.TryGetValue(CosmosCacheSessionConverter.IdAttributeName, out JToken idJToken))
             {
-                throw new JsonReaderException("Missing id on Cosmos DB session item.");
+                throw new JsonReaderException("Missing 'id' on Cosmos DB session item.");
             }
 
             cosmosCacheSession.SessionKey = idJToken.Value<string>();
 
             if (!jObject.TryGetValue(CosmosCacheSessionConverter.ContentAttributeName, out JToken contentJToken))
             {
-                throw new JsonReaderException("Missing id on Cosmos DB session item.");
+                throw new JsonReaderException("Missing 'content' on Cosmos DB session item.");
             }
 
             cosmosCacheSession.Content = Convert.FromBase64String(contentJToken.Value<string>());

--- a/tests/unit/CosmosSessionSerializationTests.cs
+++ b/tests/unit/CosmosSessionSerializationTests.cs
@@ -78,5 +78,17 @@ namespace Microsoft.Extensions.Caching.Cosmos.Tests
             string serialized = JsonConvert.SerializeObject(existingSession);
             Assert.Equal(expectedContract , serialized);
         }
+
+        [Fact]
+        public void MissingRequiredProperties()
+        {
+            const string withoutId = "{\"content\":\"AQ==\",\"ttl\":5,\"isSlidingExpiration\":true,\"absoluteSlidingExpiration\":10}";
+            JsonReaderException withoutIdException = Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<CosmosCacheSession>(withoutId));
+            Assert.Contains("Missing 'id'", withoutIdException.Message);
+
+            const string withoutContent = "{\"id\":\"1\", \"ttl\":5,\"isSlidingExpiration\":true,\"absoluteSlidingExpiration\":10}";
+            JsonReaderException withoutContentException = Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<CosmosCacheSession>(withoutContent));
+            Assert.Contains("Missing 'content'", withoutContentException.Message);
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/issues/61