### PR TITLE
Add support for System.Text.Json clients

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## <a name="1.8.0"/> 1.8.0 - 2025-04-20
+
+### Added
+
+- [#85](https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/pull/85) Support Cosmos DB SDK with System.Text.Json serialization.
+
 ## <a name="1.7.0"/> 1.7.0 - 2024-10-08
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- [#85](https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/pull/85) Support Cosmos DB SDK with System.Text.Json serialization.
+- [#87](https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/pull/87) Support Cosmos DB SDK with System.Text.Json serialization.
 
 ## <a name="1.7.0"/> 1.7.0 - 2024-10-08
 

--- a/src/CosmosCacheSession.cs
+++ b/src/CosmosCacheSession.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Extensions.Caching.Cosmos
     using Newtonsoft.Json;
 
     [JsonConverter(typeof(CosmosCacheSessionConverter))]
+    [System.Text.Json.Serialization.JsonConverter(typeof(CosmosCacheSessionConverterSTJ))]
     internal class CosmosCacheSession
     {
         public string SessionKey { get; set; }

--- a/src/CosmosCacheSessionConverterSTJ.cs
+++ b/src/CosmosCacheSessionConverterSTJ.cs
@@ -1,0 +1,121 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Extensions.Caching.Cosmos
+{
+    using System;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    internal class CosmosCacheSessionConverterSTJ : JsonConverter<CosmosCacheSession>
+    {
+        private const string ContentAttributeName = "content";
+        private const string TtlAttributeName = "ttl";
+        private const string SlidingAttributeName = "isSlidingExpiration";
+        private const string AbsoluteSlidingExpirationAttributeName = "absoluteSlidingExpiration";
+        private const string IdAttributeName = "id";
+        private const string PkAttributeName = "partitionKeyDefinition";
+
+        public override CosmosCacheSession Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected start of object");
+            }
+
+            CosmosCacheSession cosmosCacheSession = new CosmosCacheSession();
+            string content = null;
+            bool hasSessionKey = false;
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("Expected property name");
+                }
+
+                string propertyName = reader.GetString();
+                reader.Read();
+
+                switch (propertyName)
+                {
+                    case IdAttributeName:
+                        string sessionKey = reader.GetString();
+                        hasSessionKey = true;
+                        cosmosCacheSession.SessionKey = sessionKey;
+                        break;
+
+                    case ContentAttributeName:
+                        content = reader.GetString();
+                        cosmosCacheSession.Content = Convert.FromBase64String(content);
+                        break;
+
+                    case TtlAttributeName:
+                        cosmosCacheSession.TimeToLive = reader.GetInt64();
+                        break;
+
+                    case SlidingAttributeName:
+                        cosmosCacheSession.IsSlidingExpiration = reader.GetBoolean();
+                        break;
+
+                    case AbsoluteSlidingExpirationAttributeName:
+                        cosmosCacheSession.AbsoluteSlidingExpiration = reader.GetInt64();
+                        break;
+
+                    case PkAttributeName:
+                        cosmosCacheSession.PartitionKeyAttribute = reader.GetString();
+                        break;
+                }
+            }
+
+            if (!hasSessionKey)
+            {
+                throw new JsonException("Missing 'id' on Cosmos DB session item.");
+            }
+
+            if (content == null)
+            {
+                throw new JsonException("Missing 'content' on Cosmos DB session item.");
+            }
+
+            return cosmosCacheSession;
+        }
+
+        public override void Write(Utf8JsonWriter writer, CosmosCacheSession value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString(IdAttributeName, value.SessionKey);
+            writer.WriteString(ContentAttributeName, Convert.ToBase64String(value.Content));
+
+            if (value.TimeToLive.HasValue)
+            {
+                writer.WriteNumber(TtlAttributeName, value.TimeToLive.Value);
+            }
+
+            if (value.IsSlidingExpiration.HasValue)
+            {
+                writer.WriteBoolean(SlidingAttributeName, value.IsSlidingExpiration.Value);
+            }
+
+            if (value.AbsoluteSlidingExpiration.HasValue)
+            {
+                writer.WriteNumber(AbsoluteSlidingExpirationAttributeName, value.AbsoluteSlidingExpiration.Value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(value.PartitionKeyAttribute)
+                && !IdAttributeName.Equals(value.PartitionKeyAttribute, StringComparison.OrdinalIgnoreCase))
+            {
+                writer.WriteString(value.PartitionKeyAttribute, value.SessionKey);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/CosmosDistributedCache.csproj
+++ b/src/CosmosDistributedCache.csproj
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd))</CurrentDate>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <ClientVersion>1.7.0</ClientVersion>
+    <ClientVersion>1.8.0</ClientVersion>
     <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' == '' ">$(ClientVersion)</Version>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(ClientVersion)-$(VersionSuffix)</Version>

--- a/src/CosmosDistributedCache.csproj
+++ b/src/CosmosDistributedCache.csproj
@@ -40,7 +40,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.43.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.47.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>

--- a/tests/emulator/CosmosCacheEmulatorTests.cs
+++ b/tests/emulator/CosmosCacheEmulatorTests.cs
@@ -116,14 +116,20 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             Assert.Equal(throughput, throughputContainer);
         }
 
-        [Fact]
-        public async Task StoreSessionData()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task StoreSessionData(bool useSystemTextJson)
         {
             const string sessionId = "sessionId";
             const int ttl = 1400;
             const int throughput = 2000;
 
             CosmosClientBuilder builder = new CosmosClientBuilder(ConfigurationManager.AppSettings["Endpoint"], ConfigurationManager.AppSettings["MasterKey"]);
+            if (useSystemTextJson)
+            {
+                builder.WithSystemTextJsonSerializerOptions(new System.Text.Json.JsonSerializerOptions());
+            }
 
             IOptions<CosmosCacheOptions> options = Options.Create(new CosmosCacheOptions(){
                 ContainerName = "session",
@@ -146,8 +152,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             Assert.Equal(data, storedSession.Content);
         }
 
-        [Fact]
-        public async Task StoreSessionData_CustomPartitionKey()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task StoreSessionData_CustomPartitionKey(bool useSystemTextJson)
         {
             const string sessionId = "sessionId";
             const int ttl = 1400;
@@ -155,6 +163,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             const string partitionKeyAttribute = "notTheId";
 
             CosmosClientBuilder builder = new CosmosClientBuilder(ConfigurationManager.AppSettings["Endpoint"], ConfigurationManager.AppSettings["MasterKey"]);
+            if (useSystemTextJson)
+            {
+                builder.WithSystemTextJsonSerializerOptions(new System.Text.Json.JsonSerializerOptions());
+            }
 
             IOptions<CosmosCacheOptions> options = Options.Create(new CosmosCacheOptions(){
                 ContainerName = "session",
@@ -182,8 +194,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             Assert.Equal(sessionId, (string)dynamicSession.Resource.notTheId);
         }
 
-        [Fact]
-        public async Task GetSessionData()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task GetSessionData(bool useSystemTextJson)
         {
             DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
 
@@ -193,6 +207,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             byte[] data = new byte[1] { 1 };
 
             CosmosClientBuilder builder = new CosmosClientBuilder(ConfigurationManager.AppSettings["Endpoint"], ConfigurationManager.AppSettings["MasterKey"]);
+            if (useSystemTextJson)
+            {
+                builder.WithSystemTextJsonSerializerOptions(new System.Text.Json.JsonSerializerOptions());
+            }
 
             IOptions<CosmosCacheOptions> options = Options.Create(new CosmosCacheOptions(){
                 ContainerName = "session",
@@ -217,8 +235,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             }
         }
 
-        [Fact]
-        public async Task RemoveSessionData()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task RemoveSessionData(bool useSystemTextJson)
         {
             DiagnosticsSink diagnosticsSink = new DiagnosticsSink();
 
@@ -228,6 +248,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             byte[] data = new byte[1] { 1 };
 
             CosmosClientBuilder builder = new CosmosClientBuilder(ConfigurationManager.AppSettings["Endpoint"], ConfigurationManager.AppSettings["MasterKey"]);
+            if (useSystemTextJson)
+            {
+                builder.WithSystemTextJsonSerializerOptions(new System.Text.Json.JsonSerializerOptions());
+            }
 
             IOptions<CosmosCacheOptions> options = Options.Create(new CosmosCacheOptions(){
                 ContainerName = "session",
@@ -255,8 +279,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             }
         }
 
-        [Fact]
-        public async Task GetSessionData_CustomPartitionKey()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task GetSessionData_CustomPartitionKey(bool useSystemTextJson)
         {
             const string sessionId = "sessionId";
             const int ttl = 1400;
@@ -265,6 +291,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             const string partitionKeyAttribute = "notTheId";
 
             CosmosClientBuilder builder = new CosmosClientBuilder(ConfigurationManager.AppSettings["Endpoint"], ConfigurationManager.AppSettings["MasterKey"]);
+            if (useSystemTextJson)
+            {
+                builder.WithSystemTextJsonSerializerOptions(new System.Text.Json.JsonSerializerOptions());
+            }
 
             IOptions<CosmosCacheOptions> options = Options.Create(new CosmosCacheOptions(){
                 ContainerName = "session",
@@ -283,8 +313,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             Assert.Equal(data, await cache.GetAsync(sessionId));
         }
 
-        [Fact]
-        public async Task RemoveSessionData_CustomPartitionKey()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task RemoveSessionData_CustomPartitionKey(bool useSystemTextJson)
         {
             const string sessionId = "sessionId";
             const int ttl = 1400;
@@ -293,6 +325,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             const string partitionKeyAttribute = "notTheId";
 
             CosmosClientBuilder builder = new CosmosClientBuilder(ConfigurationManager.AppSettings["Endpoint"], ConfigurationManager.AppSettings["MasterKey"]);
+            if (useSystemTextJson)
+            {
+                builder.WithSystemTextJsonSerializerOptions(new System.Text.Json.JsonSerializerOptions());
+            }
 
             IOptions<CosmosCacheOptions> options = Options.Create(new CosmosCacheOptions(){
                 ContainerName = "session",
@@ -428,8 +464,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             Assert.Null(await cache.GetAsync(sessionId));
         }
 
-        [Fact]
-        public async Task SlidingAndAbsoluteExpiration()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SlidingAndAbsoluteExpiration(bool useSystemTextJson)
         {
             const string sessionId = "sessionId";
             const int ttl = 10;
@@ -437,6 +475,10 @@ namespace Microsoft.Extensions.Caching.Cosmos.EmulatorTests
             const int throughput = 400;
 
             CosmosClientBuilder builder = new CosmosClientBuilder(ConfigurationManager.AppSettings["Endpoint"], ConfigurationManager.AppSettings["MasterKey"]);
+            if (useSystemTextJson)
+            {
+                builder.WithSystemTextJsonSerializerOptions(new System.Text.Json.JsonSerializerOptions());
+            }
 
             IOptions<CosmosCacheOptions> options = Options.Create(new CosmosCacheOptions(){
                 ContainerName = "session",

--- a/tests/unit/CosmosSessionSerializationSTJTests.cs
+++ b/tests/unit/CosmosSessionSerializationSTJTests.cs
@@ -1,0 +1,107 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Extensions.Caching.Cosmos.Tests
+{
+    using System;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.Fluent;
+    using Microsoft.Extensions.Caching.Cosmos;
+    using Microsoft.Extensions.Caching.Distributed;
+    using Microsoft.Extensions.Options;
+    using Moq;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+    using Xunit;
+
+    public class CosmosSessionSerializationSTJTests
+    {
+        [Fact]
+        public void ValidatesNullTtlDoesNotSerializeProperty()
+        {
+            CosmosCacheSession existingSession = new CosmosCacheSession();
+            existingSession.SessionKey = "key";
+            existingSession.Content = new byte[0];
+            string serialized = JsonSerializer.Serialize(existingSession);
+            Assert.False(serialized.Contains("\"ttl\""), "Session without expiration should not include ttl property.");
+            Assert.False(serialized.Contains("\"absoluteSlidingExpiration\""), "Session without expiration should not include absoluteSlidingExpiration property.");
+            Assert.False(serialized.Contains("\"isSlidingExpiration\""), "Session without expiration should not include isSlidingExpiration property.");
+        }
+
+        [Fact]
+        public void ValidatesCustomPartitionKeyCreatesProperty()
+        {
+            const string pkProperty = "notTheId";
+            CosmosCacheSession existingSession = new CosmosCacheSession();
+            existingSession.SessionKey = "key";
+            existingSession.Content = new byte[0];
+            existingSession.PartitionKeyAttribute = pkProperty;
+            string serialized = JsonSerializer.Serialize(existingSession);
+            Assert.True(serialized.Contains($"\"{pkProperty}\""), "Missing custom partition key.");
+        }
+
+        [Fact]
+        public void ValidatesAbsoluteSlidingExpirationDoesSerializeProperty()
+        {
+            CosmosCacheSession existingSession = new CosmosCacheSession();
+            existingSession.SessionKey = "key";
+            existingSession.Content = new byte[0];
+            existingSession.AbsoluteSlidingExpiration = 10;
+            string serialized = JsonSerializer.Serialize(existingSession);
+            Assert.True(serialized.Contains("\"absoluteSlidingExpiration\""), "Session with absolute sliding expiration should include absoluteSlidingExpiration property.");
+        }
+
+        [Fact]
+        public void ValidatesIsSlidingExpirationDoesSerializeProperty()
+        {
+            CosmosCacheSession existingSession = new CosmosCacheSession();
+            existingSession.SessionKey = "key";
+            existingSession.Content = new byte[0];
+            existingSession.IsSlidingExpiration = true;
+            string serialized = JsonSerializer.Serialize(existingSession);
+            Assert.True(serialized.Contains("\"isSlidingExpiration\""), "Session with sliding expiration should include isSlidingExpiration property.");
+        }
+
+        [Fact]
+        public void ValidatesContract()
+        {
+            const string expectedContract = "{\"id\":\"key\",\"content\":\"AQ==\",\"ttl\":5,\"isSlidingExpiration\":true,\"absoluteSlidingExpiration\":10}";
+            CosmosCacheSession existingSession = new CosmosCacheSession();
+            existingSession.SessionKey = "key";
+            existingSession.IsSlidingExpiration = true;
+            existingSession.TimeToLive = 5;
+            existingSession.AbsoluteSlidingExpiration = 10;
+            existingSession.Content = new byte[1] { 1 };
+            string serialized = JsonSerializer.Serialize(existingSession);
+            Assert.Equal(expectedContract, serialized);
+        }
+
+        [Fact]
+        public void MissingRequiredProperties()
+        {
+            const string withoutId = "{\"content\":\"AQ==\",\"ttl\":5,\"isSlidingExpiration\":true,\"absoluteSlidingExpiration\":10}";
+            JsonException withoutIdException = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CosmosCacheSession>(withoutId));
+            Assert.Contains("Missing 'id'", withoutIdException.Message);
+
+            const string withoutContent = "{\"id\":\"1\", \"ttl\":5,\"isSlidingExpiration\":true,\"absoluteSlidingExpiration\":10}";
+            JsonException withoutContentException = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CosmosCacheSession>(withoutContent));
+            Assert.Contains("Missing 'content'", withoutContentException.Message);
+        }
+
+        [Fact]
+        public void Success()
+        {
+            const string content = "{\"id\":\"someId\",\"content\":\"AQ==\",\"ttl\":5,\"isSlidingExpiration\":true,\"absoluteSlidingExpiration\":10}";
+            CosmosCacheSession session = JsonSerializer.Deserialize<CosmosCacheSession>(content);
+            Assert.NotNull(session);
+            Assert.Equal("someId", session.SessionKey);
+            Assert.Equal(5, session.TimeToLive);
+            Assert.Equal(10, session.AbsoluteSlidingExpiration);
+            Assert.True(session.IsSlidingExpiration);
+        }
+    }
+}


### PR DESCRIPTION
Adds support for customers with custom Cosmos DB SDK that uses System.Text.Json as serialization engine

Fixes https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/issues/86